### PR TITLE
Fix Lock Cleanup

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/cwa-init-remove-locks/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init-remove-locks/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-declare -a lockFiles=("ingest-processor.lock", "convert-library.lock")
+declare -a lockFiles=("ingest-processor.lock" "convert-library.lock")
 
 echo "[cwa-init-remove-locks] Checking for leftover lock files from previous instance..."
 


### PR DESCRIPTION
No comma needed, comma would be part of file name, i.e. not working